### PR TITLE
Use gnutls template for configuration.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -198,7 +198,7 @@ if test "x$PKGCONFIG" != x; then
 	if $PKGCONFIG --exists gnutls; then
 		CFLAGS="$CFLAGS `$PKGCONFIG --cflags gnutls`"
 		LIBS="$LIBS `$PKGCONFIG --libs gnutls`"
-		AC_DEFINE(HAVE_GNUTLS)
+		AC_DEFINE([HAVE_GNUTLS], 1, [gnutls])
 		PKGCONFIG_GNUTLS="gnutls >= 3.0,"
 	fi
 fi


### PR DESCRIPTION
Fixes: #110

Now able to run `autoreconf` with gnutls:
previously:
```
$ autoreconf --install --force --verbose
...
autoheader: warning: missing template: HAVE_GNUTLS
autoheader: Use AC_DEFINE([HAVE_GNUTLS], [], [Description])
autoreconf: /nix/store/q8m8sw340ndji9qmnjdl4h67l82fzbnw-autoconf-2.69/bin/autoheader failed with exit status: 1
```

currently:
```
$ autoreconf --install --force --verbose
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force
autoreconf: configure.ac: tracing
autoreconf: configure.ac: not using Libtool
autoreconf: running: /nix/store/q8m8sw340ndji9qmnjdl4h67l82fzbnw-autoconf-2.69/bin/autoconf --force
autoreconf: running: /nix/store/q8m8sw340ndji9qmnjdl4h67l82fzbnw-autoconf-2.69/bin/autoheader --force
autoreconf: configure.ac: not using Automake
autoreconf: Leaving directory `.'

$ ./configure
...
config.status: creating Makedefs
config.status: creating pappl/pappl.pc
config.status: creating config.h

$ cat config.h | grep HAVE_GNUTLS
#define HAVE_GNUTLS 1
#define HAVE_GNUTLS_RND 1
```

I'm not the best with autotools, so there may be a better solution.
