### PR TITLE
Add support for --runstatedir configure option.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -201,7 +201,7 @@ if test "x$PKGCONFIG" != x; then
 	if $PKGCONFIG --exists gnutls; then
 		CPPFLAGS="$CPPFLAGS `$PKGCONFIG --cflags gnutls`"
 		LIBS="$LIBS `$PKGCONFIG --libs gnutls`"
-		AC_DEFINE(HAVE_GNUTLS)
+		AC_DEFINE(HAVE_GNUTLS, 1, [Whether GnuTLS is present])
 		PKGCONFIG_GNUTLS="gnutls >= 3.0,"
 	fi
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -90,7 +90,7 @@ case "`$CUPSCONFIG --api-version`" in
 esac
 
 CUPS_SERVERROOT="`$CUPSCONFIG --serverroot`"
-AC_DEFINE_UNQUOTED(CUPS_SERVERROOT, "$CUPS_SERVERROOT")
+AC_DEFINE_UNQUOTED(CUPS_SERVERROOT, "$CUPS_SERVERROOT", [CUPS Server root])
 
 
 dnl Check for pkg-config, which is used for some other tests later on...


### PR DESCRIPTION
Debian's autoheader doesn't support partial `AC_DEFINE_UNQUOTED` or `AC_DEFINE` calls; these two need all 3 arguments.