### PR TITLE
Define _FILE_OFFSET_BITS=64 on linux (Issue #193)

### DIFF
--- a/configure
+++ b/configure
@@ -5080,7 +5080,7 @@ esac
         case "$host_os_name" in #(
   linux*) :
 
-	CPPFLAGS="$CPPFLAGS -D__USE_MISC -D_TIME_BITS=64"
+	CPPFLAGS="$CPPFLAGS -D__USE_MISC -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64"
      ;; #(
   darwin*) :
 

--- a/configure.ac
+++ b/configure.ac
@@ -484,7 +484,7 @@ AS_IF([test -n "$GCC"], [
 
     dnl OS-specific compiler options...
     AS_CASE(["$host_os_name"], [linux*], [
-	CPPFLAGS="$CPPFLAGS -D__USE_MISC -D_TIME_BITS=64"
+	CPPFLAGS="$CPPFLAGS -D__USE_MISC -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64"
     ], [darwin*], [
         AS_IF([test "$host_os_version" -ge 200 -a x$enable_debug != xyes], [
             # macOS 11.0 and higher support the Apple Silicon (arm64) CPUs


### PR DESCRIPTION
Removes glibc 2.34 error:
error: "_TIME_BITS=64 is allowed only with _FILE_OFFSET_BITS=64"

Fixes pappl issue #193