### PR TITLE
Updating strlcpy to papplCopyString

### DIFF
--- a/pappl/log.c
+++ b/pappl/log.c
@@ -418,7 +418,7 @@ papplLogScanner(
 
   // Prefix the message with "[Scanner foo]", making sure to not insert any
   // scanf format specifiers.
-  strlcpy(pmessage, "[Scanner ", sizeof(pmessage));
+  papplCopyString(pmessage, "[Scanner ", sizeof(pmessage));
   for (pptr = pmessage + 9, nameptr = scanner->name; *nameptr && pptr < (pmessage + 200); pptr ++)
   {
     if (*nameptr == '%')
@@ -427,7 +427,7 @@ papplLogScanner(
   }
   *pptr++ = ']';
   *pptr++ = ' ';
-  strlcpy(pptr, message, sizeof(pmessage) - (size_t)(pptr - pmessage));
+  papplCopyString(pptr, message, sizeof(pmessage) - (size_t)(pptr - pmessage));
 
   // Write the log message...
   va_start(ap, message);


### PR DESCRIPTION
@michaelrsweet @tillkamppeter This was a minor compilation problem that was creating Linker errors during build for the scanning branch. The original function used _strlcpy()_ which was simply replaced by a predefined function _papplCopyString()_ for the same purpose. Attached here is also the linker error that was generated :
<img width="1111" alt="Screenshot 2023-01-06 at 8 49 23 PM" src="https://user-images.githubusercontent.com/120595108/211085410-d929b6df-75ff-4c20-8851-c25b2cacf26a.png">
