### PR TITLE
Fix listing devices via "devices" subcommand

### DIFF
--- a/pappl/device.c
+++ b/pappl/device.c
@@ -536,7 +536,7 @@ _papplDeviceInfoCallback(
     }
   }
 
-  return (true);
+  return (false);
 }
 
 

--- a/pappl/mainloop-subcommands.c
+++ b/pappl/mainloop-subcommands.c
@@ -34,8 +34,6 @@ static pappl_system_t	*mainloop_system = NULL;
 
 static char	*copy_stdin(const char *base_name, char *name, size_t namesize);
 static pappl_system_t *default_system_cb(const char *base_name, int num_options, cups_option_t *options, void *data);
-static void	device_error_cb(const char *message, void *err_data);
-static bool	device_list_cb(const char *device_info, const char *device_uri, const char *device_id, void *data);
 static ipp_t	*get_printer_attributes(http_t *http, const char *printer_uri, const char *printer_name, const char *resource, cups_len_t num_requested, const char * const *requested);
 static char	*get_value(ipp_attribute_t *attr, const char *name, cups_len_t element, char *buffer, size_t bufsize);
 static void	print_option(ipp_t *response, const char *name);
@@ -797,7 +795,61 @@ _papplMainloopShowDevices(
     cups_len_t    num_options,		// I - Number of options
     cups_option_t *options)		// I - Options
 {
-  papplDeviceList(PAPPL_DEVTYPE_ALL, (pappl_device_cb_t)device_list_cb, (void *)cupsGetOption("verbose", num_options, options), (pappl_deverror_cb_t)device_error_cb, (void *)base_name);
+  http_t	*http;			// Server connection
+  ipp_t		*request,		// IPP request
+		*response;		// IPP response
+  ipp_attribute_t *attr;		// IPP attribute
+
+
+  // Connect to/start up the server and get the destination printer...
+  if ((http = _papplMainloopConnect(base_name, true)) == NULL)
+    return (1);
+
+  request = ippNewRequest(IPP_OP_PAPPL_FIND_DEVICES);
+  ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_URI, "system-uri", NULL, "ipp://localhost/ipp/system");
+
+  response = cupsDoRequest(http, request, "/ipp/system");
+  httpClose(http);
+
+  if (cupsLastError() != IPP_STATUS_OK)
+  {
+    _papplLocPrintf(stderr, _PAPPL_LOC("%s: Unable to get available devices: %s"), base_name, cupsLastErrorString());
+    return (1);
+  }
+
+  if ((attr = ippFindAttribute(response, "smi55357-device-col", IPP_TAG_BEGIN_COLLECTION)) != NULL)
+  {
+    int num_devices = ippGetCount(attr);
+    for (int i = 0; i < num_devices; i ++)
+    {
+      ipp_t* item = ippGetCollection(attr, i);
+      ipp_attribute_t *item_attr;
+      const char *str;
+
+      if ((item_attr = ippFindAttribute(item, "smi55357-device-uri", IPP_TAG_ZERO)) != NULL &&
+	  (str = ippGetString(item_attr, 0, NULL)) != NULL)
+      {
+	puts(str);
+
+	if (cupsGetOption("verbose", num_options, options))
+	{
+	  if ((item_attr = ippFindAttribute(item, "smi55357-device-info", IPP_TAG_ZERO)) != NULL &&
+	      (str = ippGetString(item_attr, 0, NULL)) != NULL)
+	    printf("    %s\n", str);
+	  if ((item_attr = ippFindAttribute(item, "smi55357-device-id", IPP_TAG_ZERO)) != NULL &&
+	      (str = ippGetString(item_attr, 0, NULL)) != NULL)
+	    printf("    %s\n", str);
+	}
+      }
+    }
+  }
+  else if (cupsLastError() != IPP_STATUS_ERROR_NOT_FOUND)
+  {
+    _papplLocPrintf(stderr, _PAPPL_LOC("%s: Unable to get available devices: %s"), base_name, cupsLastErrorString());
+    return (1);
+  }
+
+  ippDelete(response);
 
   return (0);
 }
@@ -1658,39 +1710,6 @@ default_system_cb(
   }
 
   return (system);
-}
-
-
-//
-// 'device_error_cb()' - Show a device error message.
-//
-
-static void
-device_error_cb(const char *message,	// I - Error message
-		void       *data)	// I - Callback data (application name)
-{
-  printf("%s: %s\n", (char *)data, message);
-}
-
-
-//
-// 'device_list_cb()' - List a device.
-//
-
-static bool				// O - `true` to stop, `false` to continue
-device_list_cb(const char *device_info,	// I - Device description
-               const char *device_uri,	// I - Device URI
-	       const char *device_id,	// I - IEEE-1284 device ID
-	       void       *data)	// I - Callback data (NULL for plain, "verbose" for verbose output)
-{
-  puts(device_uri);
-
-  if (device_info && data)
-    printf("    %s\n", device_info);
-  if (device_id && data)
-    printf("    %s\n", device_id);
-
-  return (false);
 }
 
 


### PR DESCRIPTION
Fixes issue #253

When running a Printer Application (ex. ps-printer-app) as server and doing the client call
```
ps-printer-app devices
```
the use of custom backends (schemes, like "`cups:`" for CUPS backends in pappl-retrofit) was not taken into account, as simply `papplDeviceList()` was called, with neither a system created nor the devices list polled from the running server.

One could create the system before to get the custom scheme definitions in place, but the server is usually running as root and the client doing the request as the calling user. As some backends, independent of being PAPPL's own backends or any custom backends, discover devices only as root, letting the client call producing a different usually incomplete result.

Therefore we do an `IPP_OP_PAPPL_FIND_DEVICES` IPP request to the server to let the server auto-discover the available devices and report back the results.

There is also a bug in the server's `IPP_OP_PAPPL_FIND_DEVICES` (and `IPP_OP_PAPPL_CREATE_PRINTERS`) operation. The device list callback function `_papplDeviceInfoCallback()` returns "`true`" and not "`false`" after outputting an item, making the device listing process stop on the first item. making only the first discovered device listed (or only the first discovered printer set up). This is also corrected in this commit.
