### PR TITLE
configure.ac: Fix --enable-libpam option

### DIFF
--- a/configure
+++ b/configure
@@ -737,7 +737,7 @@ enable_option_checking
 enable_libjpeg
 enable_libpng
 enable_libusb
-enable_pam
+enable_libpam
 enable_static
 enable_shared
 enable_debug
@@ -4506,10 +4506,10 @@ then :
 fi
 
 
-# Check whether --enable-pam was given.
-if test ${enable_pam+y}
+# Check whether --enable-libpam was given.
+if test ${enable_libpam+y}
 then :
-  enableval=$enable_pam;
+  enableval=$enable_libpam;
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -257,7 +257,7 @@ AS_IF([test "x$PKGCONFIG" != x -a x$enable_libusb != xno], [
 
 
 dnl PAM support...
-AC_ARG_ENABLE([pam], AS_HELP_STRING([--enable-libpam], [use libpam for authentication, default=auto]))
+AC_ARG_ENABLE([libpam], AS_HELP_STRING([--enable-libpam], [use libpam for authentication, default=auto]))
 
 AS_IF([test x$enable_libpam != xno], [
     dnl PAM needs dlopen...


### PR DESCRIPTION
Previously the option was reported as unknown when used, because the feature name in `configure.ac` was only `pam` and `autoconf` defines available options from its name, but `./configure -h` showed `--enable-libpam`.

I fixed the option to follow the help message, in case someone was using it already.