### PR TITLE
device-network.c: Fix crash in `pappl_dnssd_list()` with Avahi

### DIFF
--- a/pappl/device-network.c
+++ b/pappl/device-network.c
@@ -416,7 +416,10 @@ pappl_dnssd_list(
 
 
   devices.types   = types;
-  devices.dnssd   = cupsDNSSDNew(err_cb, err_data);
+
+  if ((devices.dnssd = cupsDNSSDNew(err_cb, err_data)) == NULL)
+    return (ret);
+
   devices.devices = cupsArrayNew((cups_array_cb_t)pappl_dnssd_compare_devices, NULL, NULL, 0, NULL, (cups_afree_cb_t)pappl_dnssd_free);
   _PAPPL_DEBUG("pappl_dnssd_find: devices=%p\n", devices);
 


### PR DESCRIPTION
If PAPPL testsuite runs in isolated environment, e.g. in mock, we cannot generate Avahi client, because Avahi is not running. This causes `_papplDNSSDInit()` to return NULL, which is later sent into `avahi_service_browser_new()`, which uses `assert()` for this argument and make the binary crash if the input is NULL.

The crash makes the testsuite fail during the build, which is useful sanity check before the package is built.