### PR TITLE
device-network.c: Fix crash in `pappl_dnssd_list()` with Avahi

### DIFF
--- a/pappl/device-network.c
+++ b/pappl/device-network.c
@@ -443,6 +443,7 @@ pappl_dnssd_list(
   DNSServiceRef		pdl_ref;	// Browse reference for _pdl-datastream._tcp
 #  else
   AvahiServiceBrowser	*pdl_ref;	// Browse reference for _pdl-datastream._tcp
+  _pappl_dns_sd_t	dnssd;		// DNS-SD service
 #  endif // HAVE_MDNSRESPONDER
 
 
@@ -467,7 +468,15 @@ pappl_dnssd_list(
   _PAPPL_DEBUG("pappl_dnssd_find: pdl_ref=%p (after)\n", pdl_ref);
 
 #  else
-  if ((pdl_ref = avahi_service_browser_new(_papplDNSSDInit(NULL), AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, "_pdl-datastream._tcp", NULL, 0, pappl_dnssd_browse_cb, devices)) == NULL)
+  if ((dnssd = _papplDNSSDInit(NULL)) == NULL)
+  {
+    _papplDeviceError(err_cb, err_data, "Unable to create DNSSD service.");
+    cupsArrayDelete(devices);
+    _papplDNSSDUnlock();
+    return (ret);
+  }
+
+  if ((pdl_ref = avahi_service_browser_new(dnssd, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, "_pdl-datastream._tcp", NULL, 0, pappl_dnssd_browse_cb, devices)) == NULL)
   {
     _papplDeviceError(err_cb, err_data, "Unable to create service browser.");
     cupsArrayDelete(devices);


### PR DESCRIPTION
If PAPPL testsuite runs in isolated environment, e.g. in mock, we cannot generate Avahi client, because Avahi is not running. This causes `_papplDNSSDInit()` to return NULL, which is later sent into `avahi_service_browser_new()`, which uses `assert()` for this argument and make the binary crash if the input is NULL.

The crash makes the testsuite fail during the build, which is useful sanity check before the package is built.