### PR TITLE
printer-driver.c: Fix crash when adding generic PS printer

### DIFF
--- a/pappl/printer-driver.c
+++ b/pappl/printer-driver.c
@@ -968,7 +968,11 @@ make_attrs(
   // printer-device-id
   if (printer->device_id)
   {
-    ippAddString(printer->attrs, IPP_TAG_PRINTER, IPP_TAG_TEXT, "printer-device-id", NULL, printer->device_id);
+    ippAddString(attrs, IPP_TAG_PRINTER, IPP_TAG_TEXT, "printer-device-id", NULL, printer->device_id);
+  }
+  else if ((attr = ippFindAttribute(printer->attrs, "printer-device-id", IPP_TAG_PRINTER)) != NULL)
+  {
+    ippAddString(attrs, IPP_TAG_PRINTER, IPP_TAG_TEXT, "printer-device-id", NULL, ippGetString(attr, 0, NULL));
   }
   else
   {
@@ -986,7 +990,10 @@ make_attrs(
     else
       mdl = mfg;			// No separator, so assume the make and model are the same
 
-    formats = ippFindAttribute(printer->driver_attrs, "document-format-supported", IPP_TAG_MIMETYPE);
+    if ((formats = ippFindAttribute(printer->attrs, "document-format-supported", IPP_TAG_MIMETYPE)) == NULL)
+      if ((formats = ippFindAttribute(printer->attrs, "document-format-default", IPP_TAG_MIMETYPE)) == NULL)
+        return (NULL);
+
     count   = ippGetCount(formats);
     for (i = 0, ptr = cmd; i < count; i ++)
     {
@@ -1026,7 +1033,7 @@ make_attrs(
 
     *ptr = '\0';
 
-    ippAddStringf(printer->attrs, IPP_TAG_PRINTER, IPP_TAG_TEXT, "printer-device-id", NULL, "MFG:%s;MDL:%s;CMD:%s;", mfg, mdl, cmd);
+    ippAddStringf(attrs, IPP_TAG_PRINTER, IPP_TAG_TEXT, "printer-device-id", NULL, "MFG:%s;MDL:%s;CMD:%s;", mfg, mdl, cmd);
   }
 
 


### PR DESCRIPTION
If legacy-printer-app is run for the first time and generic PS driver was chosen when installing the printer, the application crashes during adding the printer.

It is because the printer structure does not have device_id set, and the library tries to get data from already freed `printer->driver_attrs`. Additionally, if the device id exists in the printer, it rewrites incorrect structure (we should set device id attr in `attrs`, which we return).

The fix adds possibility to extract device id from `printer->attrs` and if device id is missing in `printer->attrs` and `document-format-supported` as well, try `document-format-default` and if this attribute is missing, return NULL.