### PR TITLE
Fix spelling of PAPPL_API_VERSION_MINOR

### DIFF
--- a/pappl/base.h
+++ b/pappl/base.h
@@ -37,7 +37,7 @@ extern "C" {
 //
 
 #  define PAPPL_API_VERSION_MAJOR	2
-#  define PAPPL_API_VERSION_MIOR	0
+#  define PAPPL_API_VERSION_MINOR	0
 
 
 //


### PR DESCRIPTION
Fortunately, there has been no release with the misspelled name, so we are free to fix it.