### PR TITLE
Add PAPPL_API_VERSION_MAJOR/MINOR defines to base.h

### DIFF
--- a/pappl/base.h
+++ b/pappl/base.h
@@ -33,6 +33,14 @@ extern "C" {
 
 
 //
+// PAPPL API version definitions...
+//
+
+#  define PAPPL_API_VERSION_MAJOR	1
+#  define PAPPL_API_VERSION_MINOR	4
+
+
+//
 // IPP operations/tags...
 //
 


### PR DESCRIPTION
Users of pappl 1.4.5 and newer should be able to access the API version information.