### PR TITLE
Fix gcc warnings

### DIFF
--- a/pappl/client-webif.c
+++ b/pappl/client-webif.c
@@ -194,6 +194,7 @@ papplClientGetForm(
       if (body_size >= body_alloc)
       {
         char *temp;			// Temporary pointer
+        size_t body_ptr_offset = bodyptr - body;
 
         if (body_alloc >= (2 * 1024 * 1024))
           break;
@@ -207,7 +208,7 @@ papplClientGetForm(
 	  return (0);
         }
 
-        bodyptr = temp + (bodyptr - body);
+        bodyptr = temp + body_ptr_offset;
         bodyend = temp + body_alloc;
         body    = temp;
       }

--- a/pappl/mainloop-subcommands.c
+++ b/pappl/mainloop-subcommands.c
@@ -949,7 +949,7 @@ _papplMainloopShowJobs(
     cups_option_t *options)		// I - Options
 {
   const char	*printer_uri,		// Printer URI
-		*printer_name;		// Printer name
+		*printer_name = NULL;	// Printer name
   char		default_printer[256],	// Default printer
 		resource[1024];		// Resource path
   http_t	*http;			// Server connection


### PR DESCRIPTION
`body` was used after `realloc()`. Calculate `bodyptr - body` before `realloc()` and use it instead.

GCC suspects that `printer_name` might be used uninitialized. It cannot be. Initialize `printer_name` anyway.