### PR TITLE
printer-raw.c: Make the inactivity timeout 2s

### DIFF
--- a/pappl/printer-raw.c
+++ b/pappl/printer-raw.c
@@ -164,7 +164,7 @@ _papplPrinterRunRaw(
 
             if ((bytes = poll(&sockp, 1, 1000)) <= 0)
 	    {
-	      if ((time(NULL) - activity) >= 60)
+	      if ((time(NULL) - activity) >= 2)
 	        break;
 	      else
 	        continue;


### PR DESCRIPTION
60s can be too long for successful transfer - it might be taken as serious performance regression in comparison to raw printing to the device itself or via CUPS.

Let's make it 2s for now - if it causes problems later, we can change it ad-hoc.