### PR TITLE
dnssd.c: Enable service registration on loopback

### DIFF
--- a/pappl/dnssd-private.h
+++ b/pappl/dnssd-private.h
@@ -52,6 +52,7 @@ typedef void *_pappl_dns_sd_t;		// DNS-SD master reference
 extern const char	*_papplDNSSDCopyHostName(char *buffer, size_t bufsize) _PAPPL_PRIVATE;
 extern int		_papplDNSSDGetHostChanges(void) _PAPPL_PRIVATE;
 extern _pappl_dns_sd_t	_papplDNSSDInit(pappl_system_t *system) _PAPPL_PRIVATE;
+extern bool		_papplDNSSDIsLoopback(const char *name) _PAPPL_PRIVATE;
 extern void		_papplDNSSDLock(void) _PAPPL_PRIVATE;
 extern const char	*_papplDNSSDStrError(int error) _PAPPL_PRIVATE;
 extern void		_papplDNSSDUnlock(void) _PAPPL_PRIVATE;

--- a/pappl/system-accessors.c
+++ b/pappl/system-accessors.c
@@ -100,6 +100,13 @@ papplSystemAddListeners(
       if (ret)
         system->port = port;
     }
+
+    if (system->hostname)
+    {
+      free(system->hostname);
+    }
+
+    system->hostname = strdup(name);
   }
   else if (name && *name == '[')
   {
@@ -128,6 +135,11 @@ papplSystemAddListeners(
       if (ret)
         system->port = port;
     }
+
+    if (system->hostname)
+      free(system->hostname);
+
+    system->hostname = strdup(name);
   }
   else
   {
@@ -159,6 +171,14 @@ papplSystemAddListeners(
         system->port = port;
         add_listeners(system, name, port, AF_INET6);
       }
+    }
+
+    if (name && !strcasecmp(name, "localhost"))
+    {
+      if (system->hostname)
+        free(system->hostname);
+
+      system->hostname = strdup(name);
     }
   }
 

--- a/pappl/system.c
+++ b/pappl/system.c
@@ -652,7 +652,7 @@ papplSystemRun(pappl_system_t *system)	// I - System
       bool		force_dns_sd = system->dns_sd_host_changes != dns_sd_host_changes;
 					// Force re-registration?
 
-      if (force_dns_sd)
+      if (!_papplDNSSDIsLoopback(system->hostname) && force_dns_sd)
         _papplSystemSetHostNameNoLock(system, NULL);
 
       if (system->dns_sd_collision || force_dns_sd)


### PR DESCRIPTION
In case users would like to prevent sharing services from printer applications to local network, restrict it to localhost and let CUPS do the sharing.

This can be done by setting `listen-hostname` in PAPPL API - this prevents accessing the public addresses, but the service is still published on those public addresses. This can be prevented if the machine hostname is changed to localhost, but that's not desired on machines IIUC.

The PR does the following:

- introduced new pappl system member `reghost`, which is used for saving `listen-hostname`,
- new public accessors for that member, `papplSystemSetRegHostName()` and `papplSystemGetRegHostName()` - user can set the member to localhost or to the current hostname
- dnssd functions will check this member, and if it is localhost, it will use loopback index
- in case of Avahi it passes NULL as hostname to let Avahi decide what hostname to use (in case of hostname conflicts - and Avahi forbids using localhost if it is not FQDN)

The result is that if reghost is set to localhost, the service is published on `.local` address, but resolved to loopback because CUPS uses DNS-SD names in URIs.