### PR TITLE
dnssd.c: Enable service registration on loopback only

### DIFF
--- a/pappl/printer-private.h
+++ b/pappl/printer-private.h
@@ -94,6 +94,8 @@ struct _pappl_printer_s			// Printer data
 //
 // Functions...
 //
+//
+extern bool		_papplDNSSDIsLoopback(const char *name) _PAPPL_PRIVATE;
 
 extern bool		_papplPrinterAddRawListeners(pappl_printer_t *printer) _PAPPL_PRIVATE;
 extern void		*_papplPrinterRunRaw(pappl_printer_t *printer) _PAPPL_PRIVATE;

--- a/pappl/system-accessors.c
+++ b/pappl/system-accessors.c
@@ -141,6 +141,13 @@ papplSystemAddListeners(
       if (ret)
         system->port = port;
     }
+
+    if (system->hostname)
+    {
+      free(system->hostname);
+    }
+
+    system->hostname = strdup(name);
   }
   else if (name && *name == '[')
   {
@@ -169,6 +176,11 @@ papplSystemAddListeners(
       if (ret)
         system->port = port;
     }
+
+    if (system->hostname)
+      free(system->hostname);
+
+    system->hostname = strdup(name);
   }
   else
   {
@@ -200,6 +212,14 @@ papplSystemAddListeners(
         system->port = port;
         add_listeners(system, name, port, AF_INET6);
       }
+    }
+
+    if (name && !strcasecmp(name, "localhost"))
+    {
+      if (system->hostname)
+        free(system->hostname);
+
+      system->hostname = strdup(name);
     }
   }
 

--- a/pappl/system.c
+++ b/pappl/system.c
@@ -677,7 +677,7 @@ papplSystemRun(pappl_system_t *system)	// I - System
       bool		force_dns_sd = system->dns_sd_host_changes != dns_sd_host_changes;
 					// Force re-registration?
 
-      if (force_dns_sd)
+      if (!_papplDNSSDIsLoopback(system->hostname) && force_dns_sd)
         _papplSystemSetHostNameNoLock(system, NULL);
 
       if (system->dns_sd_collision || force_dns_sd)


### PR DESCRIPTION
In case users would like to prevent sharing services from printer
 applications to local network, restrict it to localhost and let CUPS
 do the sharing.

This can be done by setting listen-hostname in PAPPL API - this prevents accessing the public addresses, but the service is still published on those public addresses. This can be prevented if the machine hostname is changed to localhost, but that's not desired on machines IIUC.

The PR does the following:

- introduced new pappl system member reghost, which is used for saving listen-hostname,
- new public accessors for that member, papplSystemSetRegHostName() and papplSystemGetRegHostName() - user can set the member to localhost or to the current hostname
- dnssd functions will check this member, and if it is localhost, it will use loopback index
- in case of Avahi it passes NULL as hostname to let Avahi decide what hostname to use (in case of hostname conflicts - and Avahi forbids using localhost if it is not FQDN)

The result is that if reghost is set to localhost, the service is published on .local address, but resolved to loopback because CUPS uses DNS-SD names in URIs.

PAPPL 2.x version requires CUPS PR https://github.com/OpenPrinting/cups/pull/902 to have it working.