### PR TITLE
Allowed Printer Queue When Log level Debug without Printer

### DIFF
--- a/pappl/printer.c
+++ b/pappl/printer.c
@@ -569,7 +569,8 @@ papplPrinterCreate(
   ippDelete(driver_attrs);
 
   // Add the printer to the system...
-  _papplSystemAddPrinter(system, printer, printer_id);
+  if(system->check_add_printer)
+    _papplSystemAddPrinter(system, printer, printer_id);
 
   // printer-id
   _papplRWLockWrite(printer);

--- a/pappl/system-private.h
+++ b/pappl/system-private.h
@@ -84,6 +84,8 @@ struct _pappl_system_s			// System data
   char			*log_file;		// Log filename, if any
   int			log_fd;			// Log file descriptor, if any
   pappl_loglevel_t	log_level;		// Log level
+  pappl_printer_t *test_printer;    // Test Printer for Printer Queue while Debugging
+  int    check_add_printer;    // `1` if New Printer is Created By User
   size_t		log_max_size;		// Maximum log file size or `0` for none
   bool			log_is_syslog;		// Log to system log?
   char			*subtypes;		// DNS-SD sub-types, if any

--- a/pappl/system-webif.c
+++ b/pappl/system-webif.c
@@ -468,6 +468,8 @@ _papplSystemWebAddPrinter(
       }
       else if (!status)
       {
+        
+        system->check_add_printer=1;
         pappl_printer_t *printer = papplPrinterCreate(system, 0, printer_name, driver_name, device_id, device_uri);
 					// New printer
 
@@ -715,6 +717,27 @@ _papplSystemWebHome(
   _papplClientHTMLPutLinks(client, system->links, PAPPL_LOPTIONS_PRINTER);
 
   papplSystemIteratePrinters(system, (pappl_printer_cb_t)_papplPrinterWebIteratorCallback, client);
+
+  if(system->log_level == PAPPL_LOGLEVEL_DEBUG && cupsArrayGetCount(system->printers) == 0)
+  {
+    papplClientHTMLPrintf(client,
+              "        </div>\n"
+                          "        <div class=\"col-6\">\n"
+                          "          <h1 class=\"title\">%s</h1>\n", papplClientGetLocString(client, _PAPPL_LOC("Printer Queue Debugging")));
+    
+    system->check_add_printer=0;
+
+    if(!system->test_printer)
+      system->test_printer = papplPrinterCreate(system, 0,"Test_printer","hp--910--en","1","0.0.0.0");
+
+    if(system->test_printer)
+      _papplPrinterWebIteratorCallback(system->test_printer,client);
+    
+  }
+  else
+  {
+    system->check_add_printer=1;
+  }
 
   papplClientHTMLPuts(client,
                       "        </div>\n"


### PR DESCRIPTION
Now, these changes allow user to create printer job queue without creating a printer when log level is debug.
Through these changes, a test-printer will be created and will be stored with system. Whenever user changes the log level to debug and he have not created any printer yet, then the test-printer will be visible to him using which, they can create a printer queue without adding a printer until log level is debug.
This test-printer is not being added in main printer array which will be created by user in future and this is being ensure using a variable "check_add_printer".