### PR TITLE
Saving Log Level Info-Re

### DIFF
--- a/pappl/system-loadsave.c
+++ b/pappl/system-loadsave.c
@@ -96,6 +96,29 @@ papplSystemLoadState(
       parse_contact(value, &contact);
       papplSystemSetContact(system, &contact);
     }
+    else if (!strcasecmp(line, "LogLevel"))
+    {
+      if(value[0] == 'd')
+      {
+        system->log_level =PAPPL_LOGLEVEL_DEBUG;
+      }
+      else if(value[0] == 'i')
+      {
+        system->log_level = PAPPL_LOGLEVEL_INFO;
+      }
+      else if(value[0] == 'w')
+      {
+        system->log_level = PAPPL_LOGLEVEL_WARN;
+      }
+      else if(value[0] == 'e')
+      {
+        system->log_level = PAPPL_LOGLEVEL_ERROR;
+      }
+      else if(value[0] == 'f')
+      {
+        system->log_level = PAPPL_LOGLEVEL_FATAL;
+      }
+    }
     else if (!strcasecmp(line, "AdminGroup"))
       papplSystemSetAdminGroup(system, value);
     else if (!strcasecmp(line, "DefaultPrintGroup"))
@@ -498,6 +521,29 @@ papplSystemSaveState(
 
   if (system->dns_sd_name)
     cupsFilePutConf(fp, "DNSSDName", system->dns_sd_name);
+  if (system->log_level)
+  {
+    if(system->log_level == PAPPL_LOGLEVEL_DEBUG)
+    {
+      cupsFilePutConf(fp, "LogLevel", "d");
+    }
+    else if(system->log_level == PAPPL_LOGLEVEL_INFO)
+    {
+      cupsFilePutConf(fp, "LogLevel", "i");
+    }
+    else if(system->log_level == PAPPL_LOGLEVEL_WARN)
+    {
+      cupsFilePutConf(fp, "LogLevel", "w");
+    }
+    else if(system->log_level == PAPPL_LOGLEVEL_ERROR)
+    {
+      cupsFilePutConf(fp, "LogLevel", "e");
+    }
+    else if(system->log_level == PAPPL_LOGLEVEL_FATAL)
+    {
+      cupsFilePutConf(fp, "LogLevel", "f");
+    }
+  }    
   if (system->location)
     cupsFilePutConf(fp, "Location", system->location);
   if (system->geo_location)


### PR DESCRIPTION
This pull request is extension of my previous pull request, which got deleted  by mistake when I was trying to add changes in that pull request.
What changes I'm doing with this PR is that I'm saving the log level information in state file and whenever the hp-lip-printer add is rebuilding, the initial log level will be auto-selected by loading the saved information from previous log level(if saved).
This time I have followed the coding style guidelines properly.