### PR TITLE
Fix setting groups via web ui

### DIFF
--- a/pappl/system-webif.c
+++ b/pappl/system-webif.c
@@ -1421,7 +1421,7 @@ _papplSystemWebSecurity(
 
       if ((group = cupsGetOption("admin_group", num_form, form)) != NULL)
       {
-        if (getgrnam_r(group, &grpbuf, buffer, sizeof(buffer), &grp) || !grp)
+        if (strcmp(group, "") && (getgrnam_r(group, &grpbuf, buffer, sizeof(buffer), &grp) || !grp))
           status = _PAPPL_LOC("Bad administration group.");
 	else
 	  papplSystemSetAdminGroup(system, group);
@@ -1429,7 +1429,7 @@ _papplSystemWebSecurity(
 
       if ((group = cupsGetOption("print_group", num_form, form)) != NULL)
       {
-        if (getgrnam_r(group, &grpbuf, buffer, sizeof(buffer), &grp) || !grp)
+        if (strcmp(group, "") && (getgrnam_r(group, &grpbuf, buffer, sizeof(buffer), &grp) || !grp))
         {
           status = _PAPPL_LOC("Bad print group.");
 	}
@@ -1471,7 +1471,7 @@ _papplSystemWebSecurity(
     papplClientHTMLPrintf(client,
 			  "          <table class=\"form\">\n"
 			  "            <tbody>\n"
-			  "              <tr><th><label for=\"admin_group\">%s:</label></th><td><select name\"admin_group\"><option value=\"\">%s</option>", papplClientGetLocString(client, _PAPPL_LOC("Admin Group")), papplClientGetLocString(client, _PAPPL_LOC("None")));
+			  "              <tr><th><label for=\"admin_group\">%s:</label></th><td><select name=\"admin_group\"><option value=\"\">%s</option>", papplClientGetLocString(client, _PAPPL_LOC("Admin Group")), papplClientGetLocString(client, _PAPPL_LOC("None")));
 
     setgrent();
     while ((grp = getgrent()) != NULL)
@@ -1481,7 +1481,7 @@ _papplSystemWebSecurity(
 
     papplClientHTMLPrintf(client,
 			  "</select></td></tr>\n"
-			  "              <tr><th><label for=\"print_group\">%s:</label></th><td><select name\"print_group\"><option value=\"\">%s</option>", papplClientGetLocString(client, _PAPPL_LOC("Print Group")), papplClientGetLocString(client, _PAPPL_LOC("None")));
+			  "              <tr><th><label for=\"print_group\">%s:</label></th><td><select name=\"print_group\"><option value=\"\">%s</option>", papplClientGetLocString(client, _PAPPL_LOC("Print Group")), papplClientGetLocString(client, _PAPPL_LOC("None")));
 
     setgrent();
     while ((grp = getgrent()) != NULL)


### PR DESCRIPTION
The template is generated incorrectly, so when form data are sent via POST, it does not contain new values for groups to save.

Additionally, set the default value to `none` and make sure the code does not take the value as a bad value.