### PR TITLE
Fail if printer options validation fails

### DIFF
--- a/pappl/printer.c
+++ b/pappl/printer.c
@@ -561,7 +561,11 @@ papplPrinterCreate(
     return (NULL);
   }
 
-  papplPrinterSetDriverData(printer, &driver_data, driver_attrs);
+  if (!papplPrinterSetDriverData(printer, &driver_data, driver_attrs)) {
+    errno = EINVAL;
+    _papplPrinterDelete(printer);
+    return (NULL);
+  }
   ippDelete(driver_attrs);
 
   // Add the printer to the system...


### PR DESCRIPTION
Without this change, the printer is added but without its driver_data set, which leads to segfaults when submitting a job.

I encountered this with lprint using the brother backend with a p-touch printer (which set  up its media incorrectly, I'll submit a PR there for that), using pappl 1.4.0 (not master because I only have CUPS 2.3). I'm submitting this against the v1.4.x branch since I think this is a bugfix for that branch, but I can submit against master too if you prefer (but not test that).