### PR TITLE
job-process.c: Check the `printfile_cb` for NULL in `filter_raw()`

### DIFF
--- a/pappl/job-process.c
+++ b/pappl/job-process.c
@@ -1162,7 +1162,7 @@ filter_raw(
 {
   papplJobSetImpressions(job, 1);
 
-  if (!(job->printer->driver_data.printfile_cb)(job, doc_number, options, device))
+  if (!job->printer->driver_data.printfile_cb || !(job->printer->driver_data.printfile_cb)(job, doc_number, options, device))
     return (false);
 
   papplJobSetImpressionsCompleted(job, 1);


### PR DESCRIPTION
legacy-printer-app does not set `printfile_cb`, which occassionally ends up in crash during printing via `legacy-printer-app submit`. It might be an issue in legacy-printer-app as well, but we should protect the library against crashes.

Related: https://github.com/OpenPrinting/pappl-retrofit/issues/30