### PR TITLE
stop png read from looping endlessly

### DIFF
--- a/pappl/job-filter.c
+++ b/pappl/job-filter.c
@@ -897,12 +897,13 @@ _papplJobFilterPNG(
   // Print the image...
   ret = papplJobFilterImage(job, device, options, pixels, width, height, depth, (int)png_get_x_pixels_per_inch(pp, info), false);
 
+  png_read_end(pp, info);
+
   // Finish up...
   finish_png:
 
   if (pp && info)
   {
-    png_read_end(pp, info);
     png_destroy_read_struct(&pp, &info, NULL);
     pp   = NULL;
     info = NULL;


### PR DESCRIPTION
If a non-png file is printed with "document-format" set to "image/png" pappl will end up in an endless loop where the error handling code in libpng calls longjump, which in turn performs a goto to finish_png, where png_read_end() is called, causing yet another longjump, and then a goto to finish_png again. I encountered this when I by mistake passed a jpeg file instead of a png file. Use the attached ipptool script to reproduce.

The fix is simple, move png_read_end to before finish_png so that it's only called if the file was read successfully.

This fix probably should also apply to the master branch, but since master requires a newer version of libcups than I have on my machine I can't test that.
[ipp-print-job.txt](https://github.com/user-attachments/files/22054180/ipp-print-job.txt)
