### PR TITLE
Minor test runner fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 /pappl/pappl-exec
 /pappl/parse-lock-log
 /Makedefs
+/testsuite/test.log
 /testsuite/testhttpmon
 /testsuite/testmainloop
 /testsuite/testpappl

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -55,7 +55,7 @@ test:		testpappl
 	echo "./testhttpmon"
 	./testhttpmon 2>>test.log
 	echo "./testqrcode"
-	./testhttpmon 2>>test.log
+	./testqrcode 2>>test.log
 	echo "./testpappl -c -l testpappl.log -L debug -d testpappl.spool -o testpappl.output -t api,client,pwg-raster,infra,idle-shutdown"
 	PAPPL_EXEC=../pappl/pappl-exec ./testpappl -c -l testpappl.log -L debug -d testpappl.spool -o testpappl.output -t api,client,pwg-raster,infra,idle-shutdown 2>>test.log
 	date >>test.log


### PR DESCRIPTION
This is a minor fix for the `make test` test runner:

* The testhttpmon test was called twice by `make test` and testqrcode was not called
* Also the `test.log` file is not .gitignored so it clogs up the Git tree as the executed test results land in-tree.