### PR TITLE
Lock printers_rwlock when deleting a printer (OCU-01-014)

### DIFF
--- a/pappl/printer.c
+++ b/pappl/printer.c
@@ -286,7 +286,9 @@ papplPrinterDelete(
 
   // Remove the printer from the system object...
   _papplRWLockWrite(system);
+  cupsRWLockWrite(&system->printers_rwlock);
   cupsArrayRemove(system->printers, printer);
+  cupsRWUnlock(&system->printers_rwlock);
   _papplRWUnlock(system);
 
   _papplPrinterDelete(printer);


### PR DESCRIPTION
### What this fixes

Fixes #432 (audit finding OCU-01-014).

`papplPrinterDelete()` removes the printer from `system->printers` under `_papplRWLockWrite(system)` (`system->rwlock`), but readers like `ipp_get_printers()` ; and the creation path in `system-printer.c` which guard that array with `system->printers_rwlock`. Because those are separate locks, a concurrent reader holding `printers_rwlock` isn't protected against the removal and can end up iterating over a stale printer pointer.

### The fix

Take `printers_rwlock` around the `cupsArrayRemove()`, so deletion synchronises with readers the same way creation does. The lock order (`system->rwlock` then `printers_rwlock`) matches `system-printer.c`, so there's no ordering inversion.